### PR TITLE
Allow null values in the source object

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.swp
 node_modules
+.idea
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "grunt-contrib-uglify": "^0.6.0",
     "grunt-contrib-watch": "latest",
     "mocha": "^1.21.4",
-    "object-sizeof": "^0.1.2",
+    "object-sizeof": "^1.2.0",
     "socket.io": "^1.1.0"
   }
 }

--- a/packetflattener.js
+++ b/packetflattener.js
@@ -50,16 +50,19 @@
     }
     else if (typeof(template) === "object") {
       if (template instanceof Array) {
-	array.push(data.length);
-	for (var i = 0; i < data.length; ++i) {
-	  arguments.callee(data[i], template[0], array);
-	}
+        array.push(data.length);
+        for (var i = 0; i < data.length; ++i) {
+          arguments.callee(data[i], template[0], array);
+        }
       }
       else if (template.constructor && template.constructor === Object) {
-	for (var key in template) {
-	  if (typeof(data[key]) === "undefined") arguments.callee(template[key], template[key], array);
-	  else arguments.callee(data[key], template[key], array);
-	}
+        for (var key in template) {
+          if (data[key] === null || typeof(data[key]) === "undefined") {
+            arguments.callee(template[key], template[key], array);
+          } else {
+            arguments.callee(data[key], template[key], array);
+          }
+        }
       }
     }
   }

--- a/test/jsoncompress.js
+++ b/test/jsoncompress.js
@@ -39,6 +39,7 @@ var object = {
   customObject: customObject,
   active: true,
   visible: false,
+  testDefaultValue: null,
   position: {
     x: 10000.35453475,
     y: 5000.4,
@@ -76,6 +77,7 @@ var template = {
   customObject: Uppercase,
   active: true,
   visible: false,
+  testDefaultValue: 100,
   position: {
     x: 0,
     y: 0,
@@ -122,19 +124,26 @@ describe('jsoncompress', function () {
     var decompressed = jsoncompress.decompress(compressed, template);
     var decompressedLossyDecimal = jsoncompress.decompress(compressedLossyDecimal, template);
 
+    it('should take default value from the template ', function () {
+      assert.equal(decompressed.testDefaultValue, template.testDefaultValue);
+    });
+
     it('should convert properties back to the same type', function () {
       Object.keys(object).forEach(function (key) {
-	if (typeof object[key] === 'object') {
-	  Object.keys(object[key]).forEach(function (subKey) {
-	    assert.equal(typeof decompressed[key][subKey], typeof object[key][subKey]);
-	  });
-	}
-
-	assert.equal(typeof decompressed[key], typeof object[key]);
+	      if (object[key] && typeof object[key] === 'object') {
+	        Object.keys(object[key]).forEach(function (subKey) {
+	            assert.equal(typeof decompressed[key][subKey], typeof object[key][subKey]);
+	        });
+	      }
+        var expectedType = object[key] === null || object[key] === undefined
+          ? typeof template[key]
+          : typeof object[key];
+	      assert.equal(typeof decompressed[key], expectedType);
       });
     });
 
-    it('should decompress to exactly the same value', function () {
+    it('should decompress to exactly the same value except testDefaultValue', function () {
+      object.testDefaultValue = template.testDefaultValue;
       assert.equal(
 	JSON.stringify(decompressed),
 	JSON.stringify(object)


### PR DESCRIPTION
Current version doesn't allow null value in any property of the source object. It takes null as an object and throws an exception. This fix makes the following work:
```
const template = { a: 10, b: 0 };
const compressed = jsoncompress.compress({ a: null, b: 5 }, template);
const decompressed = jsoncompress.decompress(compressed, template);
console.log(decompressed); // { a: 10, b:5 }
```
